### PR TITLE
Fix __shfl_down cuda error

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ class RNNTLoss(Loss):
 From the repo test with:
 
 ```bash
-python test/test.py 10 300 100 50 --mx
+python test/test.py --mx
 ```
 
 ## Reference

--- a/rnnt_include/detail/reduce.h
+++ b/rnnt_include/detail/reduce.h
@@ -30,7 +30,7 @@ struct CTAReduce {
 
         T shuff;
         for (int offset = warp_size / 2; offset > 0; offset /= 2) {
-            shuff = __shfl_down(x, offset);
+            shuff = __shfl_down_sync(0xFFFFFFFF, x, offset);
             if (tid + offset < count && tid < offset)
                 x = g(x, shuff);
         }


### PR DESCRIPTION
Fix MXNet build error `identifier "__shfl_down" is undefined`
Same as https://github.com/SeanNaren/deepspeech.pytorch/issues/397#issuecomment-470784387
Tested on MXNet 1.5.x, cuda 9.2 and 10.1